### PR TITLE
refactor: Remove unused pseudo-element from chat window styles

### DIFF
--- a/src/components/VirtualAssistant/VirtualAssistant.module.scss
+++ b/src/components/VirtualAssistant/VirtualAssistant.module.scss
@@ -380,18 +380,6 @@
             border-bottom-left-radius: 8px;
             border: 1px solid var(--border-cl);
             position: relative;
-
-            &::after {
-                content: '';
-                position: absolute;
-                top: 0;
-                left: -9px;
-                width: 0;
-                height: 0;
-                border: 8px solid transparent;
-                border-right-color: var(--background-secondary);
-                border-left: none;
-            }
         }
     }
 


### PR DESCRIPTION
This pull request simplifies the styling of the `VirtualAssistant` component by removing unnecessary CSS rules.

Styling simplification:

* [`src/components/VirtualAssistant/VirtualAssistant.module.scss`](diffhunk://#diff-73668286e9df834887aa939d83ea82aaff4b385cd11f5d8534ddd0232552488fL383-L394): Removed the `::after` pseudo-element, which was used to create a decorative triangle. This change reduces complexity and improves maintainability.